### PR TITLE
Mobile navmenu fix in IE

### DIFF
--- a/lib/components/header/index.css
+++ b/lib/components/header/index.css
@@ -231,7 +231,7 @@
   .Header--withOpenNav .Header-nav {
     opacity: 1;
     visibility: visible;
-
+    flex-basis: auto !important; /* IE fix */
     height: auto;
     max-height: 1000px;
     margin-top: calc(var(--baseline-px) * 3);

--- a/lib/components/subnavigation/index.css
+++ b/lib/components/subnavigation/index.css
@@ -20,8 +20,7 @@
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
-  /* IE fix */
-  overflow-y: hidden;
+  overflow-y: hidden;   /* IE fix */
   height: 100%;
   max-width: 100%;
   animation: slideIn 0.75s forwards;
@@ -34,6 +33,7 @@
   padding: 8px;
   transition: 250ms;
   text-decoration: none;
+  flex-wrap: nowrap;   /* not sure FIX: iOS v.10.3.3, Safari in iPad */
 }
 
 .SubNav-link--active {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "astridlindgren.se",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astridlindgren.se",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Main app for astridlindgren.se",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Trello card:
- Meny expanderas över innehåll istället för att trycka ner innehåll i IE11.
https://trello.com/c/HontPiKm