### PR TITLE
CharacterMenu now supports multiple rows using JS

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -28,7 +28,8 @@ function setupContainers (appState) {
   var containers = {
     header: require('../components/header/container'),
     section: require('../components/section/container'),
-    filter: require('../components/filter/container')
+    filter: require('../components/filter/container'),
+    charactermenu: require('../components/charactermenu/container')
   }
   containerElements.forEach(function initContainer (element) {
     var name = element.dataset.container

--- a/lib/components/charactermenu/container/index.js
+++ b/lib/components/charactermenu/container/index.js
@@ -1,0 +1,22 @@
+
+module.exports = function CharacterMenu (appState, element) {
+  const title = element.querySelector('.js-titleLink')
+  title.addEventListener('click', event => toggleMenu(element))
+  setCustomProps(element, title)
+}
+
+function toggleMenu (menu) {
+  menu.classList.toggle('open')
+}
+
+function setCustomProps (element, title, delayForCustomFontLoad = 300) {
+  setTimeout(function setHeightProp () {
+    if (element.style.setProperty) {
+      let height = title.offsetHeight
+      if (typeof height === 'number') {
+        element.classList.add('CharacterMenu--dynamicHeight')
+        element.style.setProperty('--CharacterMenuTitleHeight', `${title.offsetHeight}px`)
+      }
+    }
+  }, delayForCustomFontLoad)
+}

--- a/lib/components/charactermenu/index.css
+++ b/lib/components/charactermenu/index.css
@@ -96,11 +96,20 @@
     overflow: hidden;
     box-shadow: none !important;
   }
+  .CharacterMenu--dynamicHeight {
+    height: calc(10vw + var(--CharacterMenuTitleHeight));
+  }
   .CharacterMenu.open { height: auto; }
 
   .CharacterMenu-titleLink { display: block; }
 
-  .CharacterMenu-toggle-icon { display: block; position: absolute; right: 5vw; top: calc(5vw + 5px); transition: 250ms; }
+  .CharacterMenu-toggle-icon {
+    display: block;
+    position: absolute;
+    right: 5vw;
+    top: calc(5vw + 5px);
+    transition: transform 250ms ease;
+  }
   .CharacterMenu.open .CharacterMenu-toggle-icon { transform: rotate(180deg) }
 
   .CharacterMenu-container {
@@ -112,7 +121,7 @@
     height: 100%;
   }
   .CharacterMenu-title {
-    padding: calc(5vw - 2px) 0px;
+    padding: calc(5vw - 1px) 0px;
   }
   .CharacterMenu-link {
     display: block;

--- a/lib/components/charactermenu/index.js
+++ b/lib/components/charactermenu/index.js
@@ -44,8 +44,8 @@ function characterMenu (state, currentPageId) {
   })
   var accent = state.character_menu ? state.character_menu.accent : false
   return html`
-    <div class="CharacterMenu" ${raw(getStyles(accent))}>
-      <div class="${titleClasses}"><a class="CharacterMenu-titleLink" onclick="toggleMenu();">${state.character_menu.title}<img class="CharacterMenu-toggle-icon" src="/character_menu_icon.svg"/></a></div>
+    <div class="CharacterMenu" data-container="charactermenu" ${raw(getStyles(accent))}>
+      <div class="${titleClasses}"><a class="CharacterMenu-titleLink js-titleLink">${state.character_menu.title}<img class="CharacterMenu-toggle-icon" src="/character_menu_icon.svg"/></a></div>
       <div class="CharacterMenu-container">
         ${navItems.map(linkObj => {
           let linkClasses = className('CharacterMenu-link', {
@@ -55,12 +55,6 @@ function characterMenu (state, currentPageId) {
         })}
       </div>
     </div>
-    <script>
-      function toggleMenu () {
-        var menu = document.querySelector('.CharacterMenu')
-        menu.classList.toggle('open');
-      }
-    </script>
   `
 }
 


### PR DESCRIPTION
Issue resolved: CharacterMenu-title breaks design when it is two rows.

How: dynamically communicate height of title with CSS custom property, which works in supported browsers except IE11 according to my testing. 